### PR TITLE
Check fix

### DIFF
--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -47,23 +47,23 @@ class ChessPiece < ApplicationRecord
     method_return = false
     original_coord = [x, y]
     king_coord = find_king_coord(x_target, y_target)
-
-    #temporarly remove a piece that would be capture while verifying check status in case it would remove check status
-    if occupied?(x_target, y_target)
-      captured_piece = find_piece(x_target, y_target)
-      captured_piece_coord = [captured_piece.x, captured_piece.y]
-      capture(x_target, y_target)
-    end
+    temp_capt_id_and_coord = temp_capture(x_target, y_target) if occupied?(x_target, y_target)
     #temporarly move piece to verify check status
     update_attributes(x: x_target, y: y_target)
-    if king_in_check?(king_coord[0], king_coord[1])
-      method_return = true
-    end
+    method_return = true if king_in_check?(king_coord[0], king_coord[1])
     #return moved piece to it's original coord
     update_attributes(x: original_coord[0], y: original_coord[1])
     #return captured piece if there is
-    undo_temp_capture(captured_piece.id, captured_piece_coord) unless captured_piece.nil?
+    undo_temp_capture(temp_capt_id_and_coord[0], temp_capt_id_and_coord[1]) unless temp_capt_id_and_coord.empty?
     return method_return
+  end
+
+  def temp_capture(x_target, y_target)
+    #temporarly remove a piece that would be capture while verifying check status in case it would remove check status
+    piece = find_piece(x_target, y_target)
+    id_and_coord = [piece.id, [piece.x, piece.y]]
+    capture(x_target, y_target)
+    return id_and_coord
   end
 
   def find_king_coord(x_target, y_target)

--- a/app/models/chess_piece.rb
+++ b/app/models/chess_piece.rb
@@ -44,20 +44,21 @@ class ChessPiece < ApplicationRecord
 
   # illegal_move places or leaves one's king in check.
   def illegal_move?(x_target, y_target)
+    method_return = false
+    original_coord = [x, y]
+    king_coord = []
     if type == 'King'
-      king_x = x_target
-      king_y = y_target
-      return true if king_in_check?(king_x, king_y)
+      king_coord << x_target << y_target
     else
-      original_coord = [x, y]
       king = game.chess_pieces.where(type: 'King', color: color).first
-      update_attributes(x: x_target, y: y_target)
-      if king_in_check?(king.x, king.y)
-        update_attributes(x: original_coord[0], y: original_coord[1])
-        return true
-      end
+      king_coord << king.x << king.y
     end
-    false
+    update_attributes(x: x_target, y: y_target)
+    if king_in_check?(king_coord[0], king_coord[1])
+      method_return = true
+    end
+    update_attributes(x: original_coord[0], y: original_coord[1])
+    return method_return
   end
 
   def king_in_check?(king_x, king_y)

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -25,7 +25,7 @@ class Pawn < ChessPiece
       if (x_target - x).abs == 1
         if occupied?(x_target, y_target) # capture move
           target = ChessPiece.where(game_id: game_id, x: x_target, y: y_target).first
-          return target.color == 'black' ? true : false
+          return target.color == 'white' ? true : false
         end
       else
         return true if !occupied?(x_target, y_target) # regular move


### PR DESCRIPTION
Added much logic to illegal_move? for a bunch of situations where king would be in check depending on the outcome of the move. Mostly saved initial positions of moved piece and target square piece while evaluating check status, then change positions back for both pieces.